### PR TITLE
📝 CHORE: Auth 도메인 Swagger 문서화

### DIFF
--- a/src/main/java/shop/catchmind/auth/presentation/AuthController.java
+++ b/src/main/java/shop/catchmind/auth/presentation/AuthController.java
@@ -46,7 +46,7 @@ public class AuthController {
                     " isExisted = false의 경우, 동일한 이메일이 없습니다.")
     })
     public ResponseEntity<IsExistedEmailResponse> isValidEmail(
-            @RequestBody final IsExistedEmailRequest request
+            @RequestBody @Valid final IsExistedEmailRequest request
     ) {
         return ResponseEntity.ok(authService.isExistedEmail(request));
     }

--- a/src/main/java/shop/catchmind/auth/presentation/AuthController.java
+++ b/src/main/java/shop/catchmind/auth/presentation/AuthController.java
@@ -1,5 +1,10 @@
 package shop.catchmind.auth.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -8,6 +13,7 @@ import shop.catchmind.auth.dto.request.IsExistedEmailRequest;
 import shop.catchmind.auth.dto.request.SignUpRequest;
 import shop.catchmind.auth.dto.response.IsExistedEmailResponse;
 
+@Tag(name = "Auth API", description = "인증/인가 관련 API")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -16,14 +22,29 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/sign-up")
+    @Operation(
+            summary = "회원가입",
+            description = "이름, 이메일, 비밀번호를 받아 회원가입을 진행합니다."
+    )
+    @ApiResponses(value={
+            @ApiResponse(responseCode = "200", description = "회원가입 성공입니다.")
+    })
     public ResponseEntity<Object> signUp(
-            @RequestBody final SignUpRequest request
+            @RequestBody @Valid final SignUpRequest request
     ) {
         authService.signUp(request);
         return ResponseEntity.ok(null);
     }
 
     @GetMapping("/email")
+    @Operation(
+            summary = "이메일 중복 검사",
+            description = "이메일을 받아 중복 여부를 검사합니다."
+    )
+    @ApiResponses(value={
+            @ApiResponse(responseCode = "200", description = "isExisted = true의 경우, 중복 이메일이 존재합니다." +
+                    " isExisted = false의 경우, 동일한 이메일이 없습니다.")
+    })
     public ResponseEntity<IsExistedEmailResponse> isValidEmail(
             @RequestBody final IsExistedEmailRequest request
     ) {

--- a/src/main/java/shop/catchmind/common/presentation/HealthCheckController.java
+++ b/src/main/java/shop/catchmind/common/presentation/HealthCheckController.java
@@ -1,8 +1,10 @@
 package shop.catchmind.common.presentation;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 public class HealthCheckController {
     @GetMapping("/health")

--- a/src/main/java/shop/catchmind/global/config/SwaggerConfig.java
+++ b/src/main/java/shop/catchmind/global/config/SwaggerConfig.java
@@ -2,21 +2,40 @@ package shop.catchmind.global.config;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+import shop.catchmind.auth.filter.CustomJsonAuthenticationFilter;
 
 import java.util.List;
+import java.util.Optional;
+
+import static shop.catchmind.auth.constant.AuthProcessingConstant.*;
 
 @Configuration
+@RequiredArgsConstructor
 public class SwaggerConfig {
 
+    private final ApplicationContext applicationContext;
     private final String securitySchemeName = "bearerAuth";
 
     @Bean
@@ -43,7 +62,45 @@ public class SwaggerConfig {
                                 )
                 )
                 .info(info)
-                .servers(List.of(prodServer));
+                .servers(List.of(prodServer, localServer));
+    }
+
+    @Bean
+    public OpenApiCustomizer springSecurityLoginEndpointCustomizer() {
+        FilterChainProxy filterChainProxy = applicationContext.getBean(
+                AbstractSecurityWebApplicationInitializer.DEFAULT_FILTER_NAME,
+                FilterChainProxy.class);
+        return openAPI -> {
+            for (SecurityFilterChain filterChain : filterChainProxy.getFilterChains()) {
+                Optional<CustomJsonAuthenticationFilter> optionalFilter =
+                        filterChain.getFilters().stream()
+                                .filter(CustomJsonAuthenticationFilter.class::isInstance)
+                                .map(CustomJsonAuthenticationFilter.class::cast)
+                                .findAny();
+                if (optionalFilter.isPresent()) {
+                    CustomJsonAuthenticationFilter filter = optionalFilter.get();
+                    Operation operation = new Operation();
+                    Schema<?> schema = new ObjectSchema()
+                            .addProperty(USERNAME_KEY, new StringSchema())
+                            .addProperty(PASSWORD_KEY, new StringSchema());
+                    RequestBody requestBody = new RequestBody().content(
+                            new Content().addMediaType(
+                                    org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+                                    new MediaType().schema(schema)));
+                    operation.requestBody(requestBody);
+                    ApiResponses apiResponses = new ApiResponses();
+                    apiResponses.addApiResponse(String.valueOf(HttpStatus.OK.value()),
+                            new ApiResponse().description(HttpStatus.OK.getReasonPhrase()));
+                    apiResponses.addApiResponse(String.valueOf(HttpStatus.BAD_REQUEST.value()),
+                            new ApiResponse().description(HttpStatus.BAD_REQUEST.getReasonPhrase()));
+                    operation.responses(apiResponses);
+                    operation.addTagsItem("Auth API");
+                    operation.summary("로그인").description("아이디와 비밀번호를 받아 로그인합니다.");
+                    PathItem pathItem = new PathItem().post(operation);
+                    openAPI.getPaths().addPathItem(DEFAULT_LOGIN_REQUEST_URL, pathItem);
+                }
+            }
+        };
     }
 
 }

--- a/src/main/java/shop/catchmind/gpt/presentation/GptController.java
+++ b/src/main/java/shop/catchmind/gpt/presentation/GptController.java
@@ -1,5 +1,6 @@
 package shop.catchmind.gpt.presentation;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import shop.catchmind.gpt.application.GptService;
 import shop.catchmind.gpt.dto.InterpretDto;
 
+@Hidden
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/gpt")


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
-  `feature/11-auth`

### 💡 작업동기
- `Auth` 도메인에 대한 문서화가 필요합니다.

### 🔑 주요 변경사항
- Login 문서화
- 로컬 서버 문서화 추가
- 이메일 중복 검사 `@Valid` 추가

### 🏞 스크린샷
![image](https://github.com/Sketcher-s/CatchMind-BE/assets/52543606/1c4c586b-28fe-4c8f-8405-cea2a7e1bb29)

### 관련 이슈
- #11 