### PR TITLE
✨ FEAT: Picture 도메인 API 구현 (검사 상세 조회, 검사 제목 수정)

### DIFF
--- a/src/main/java/shop/catchmind/auth/application/AuthService.java
+++ b/src/main/java/shop/catchmind/auth/application/AuthService.java
@@ -22,10 +22,10 @@ public class AuthService {
         memberRepository.save(member);
     }
 
+    @Transactional(readOnly = true)
     public IsExistedEmailResponse isExistedEmail(final String email) {
         return IsExistedEmailResponse.builder()
                 .isExisted(memberRepository.existsByEmail(email))
                 .build();
-
     }
 }

--- a/src/main/java/shop/catchmind/auth/presentation/AuthController.java
+++ b/src/main/java/shop/catchmind/auth/presentation/AuthController.java
@@ -20,7 +20,6 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/sign-up")
     @Operation(
             summary = "회원가입",
             description = "이름, 이메일, 비밀번호를 받아 회원가입을 진행합니다."
@@ -28,6 +27,7 @@ public class AuthController {
     @ApiResponses(value={
             @ApiResponse(responseCode = "200", description = "회원가입 성공입니다.")
     })
+    @PostMapping("/sign-up")
     public ResponseEntity<Object> signUp(
             @RequestBody @Valid final SignUpRequest request
     ) {
@@ -35,7 +35,6 @@ public class AuthController {
         return ResponseEntity.ok(null);
     }
 
-    @GetMapping("/{email}")
     @Operation(
             summary = "이메일 중복 검사",
             description = "이메일을 받아 중복 여부를 검사합니다."
@@ -44,6 +43,7 @@ public class AuthController {
             @ApiResponse(responseCode = "200", description = "isExisted = true의 경우, 중복 이메일이 존재합니다." +
                     " isExisted = false의 경우, 동일한 이메일이 없습니다.")
     })
+    @GetMapping("/{email}")
     public ResponseEntity<IsExistedEmailResponse> isValidEmail(
             @PathVariable final String email
     ) {

--- a/src/main/java/shop/catchmind/picture/application/PictureService.java
+++ b/src/main/java/shop/catchmind/picture/application/PictureService.java
@@ -20,6 +20,7 @@ import shop.catchmind.gpt.dto.NaturalLanguageDto;
 import shop.catchmind.picture.domain.Picture;
 import shop.catchmind.picture.dto.PictureDto;
 import shop.catchmind.picture.dto.response.InterpretResponse;
+import shop.catchmind.picture.dto.response.PictureResponse;
 import shop.catchmind.picture.repository.PictureRepository;
 
 import java.io.IOException;
@@ -67,8 +68,20 @@ public class PictureService {
         return InterpretResponse.of(PictureDto.of(picture));
     }
 
+    @Transactional(readOnly = true)
+    public PictureResponse getPicture(final Long authId, final Long pictureId) {
+        Picture picture = pictureRepository.findById(pictureId)
+                .orElseThrow(RuntimeException::new);    // TODO: Exception 처리 필요
+
+        if (!picture.getMemberId().equals(authId)) {
+            throw new RuntimeException(); // TODO: Exception 처리 필요
+        }
+
+        return PictureResponse.of(PictureDto.of(picture));
+    }
+
     // 정규 표현식을 사용하여 "(숫자)" 패턴을 제거
-    private String removeNumbersInParentheses(String input) {
+    private String removeNumbersInParentheses(final String input) {
         return input.replaceAll("\\(\\d+\\)", "");
     }
 }

--- a/src/main/java/shop/catchmind/picture/domain/Picture.java
+++ b/src/main/java/shop/catchmind/picture/domain/Picture.java
@@ -38,7 +38,7 @@ public class Picture extends AuditingField {
     }
 
     @Builder
-    public Picture(Long memberId, String title, String imageUrl, String result) {
+    public Picture(final Long memberId, final String title, final String imageUrl, final String result) {
         this.memberId = memberId;
         this.title = title;
         this.imageUrl = imageUrl;

--- a/src/main/java/shop/catchmind/picture/dto/request/UpdateTitleRequest.java
+++ b/src/main/java/shop/catchmind/picture/dto/request/UpdateTitleRequest.java
@@ -1,0 +1,14 @@
+package shop.catchmind.picture.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateTitleRequest(
+        @NotBlank
+        Long id,
+
+        @Size(max = 15)
+        @NotBlank
+        String title
+) {
+}

--- a/src/main/java/shop/catchmind/picture/dto/response/PictureResponse.java
+++ b/src/main/java/shop/catchmind/picture/dto/response/PictureResponse.java
@@ -1,0 +1,16 @@
+package shop.catchmind.picture.dto.response;
+
+import lombok.Builder;
+import shop.catchmind.picture.dto.PictureDto;
+
+@Builder
+public record PictureResponse(
+        PictureDto pictureDto
+) {
+
+    public static PictureResponse of(PictureDto pictureDto) {
+        return PictureResponse.builder()
+                .pictureDto(pictureDto)
+                .build();
+    }
+}

--- a/src/main/java/shop/catchmind/picture/presentation/PictureController.java
+++ b/src/main/java/shop/catchmind/picture/presentation/PictureController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import shop.catchmind.auth.dto.AuthenticationDto;
 import shop.catchmind.picture.application.PictureService;
+import shop.catchmind.picture.dto.request.UpdateTitleRequest;
 import shop.catchmind.picture.dto.response.InterpretResponse;
 import shop.catchmind.picture.dto.response.PictureResponse;
 
@@ -43,7 +44,7 @@ public class PictureController {
             description = "요청한 ID의 그림 검사 결과의 상세 정보를 조회합니다."
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "분석이 완료되었습니다.")
+            @ApiResponse(responseCode = "200", description = "그림 검사 결과 상세 정보 조회에 성공했습니다.")
     })
     @GetMapping("/{pictureId}")
     public ResponseEntity<PictureResponse> getPicture(
@@ -52,4 +53,21 @@ public class PictureController {
     ) {
         return ResponseEntity.ok(pictureService.getPicture(auth.id(), pictureId));
     }
+
+    @Operation(
+            summary = "그림 검사 제목 수정",
+            description = "요청한 ID의 그림 검사 결과의 제목을 수정합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "그림 검사 결과의 제목 수정에 성공했습니다.")
+    })
+    @PatchMapping("/title")
+    public ResponseEntity<?> updateTitle(
+            @AuthenticationPrincipal final AuthenticationDto auth,
+            @RequestBody final UpdateTitleRequest request
+    ) {
+        pictureService.updateTitle(auth.id(), request);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/shop/catchmind/picture/presentation/PictureController.java
+++ b/src/main/java/shop/catchmind/picture/presentation/PictureController.java
@@ -13,6 +13,7 @@ import org.springframework.web.multipart.MultipartFile;
 import shop.catchmind.auth.dto.AuthenticationDto;
 import shop.catchmind.picture.application.PictureService;
 import shop.catchmind.picture.dto.response.InterpretResponse;
+import shop.catchmind.picture.dto.response.PictureResponse;
 
 @Tag(name = "Picture API", description = "그림 검사 관련 API")
 @RestController
@@ -22,18 +23,33 @@ public class PictureController {
 
     private final PictureService pictureService;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             summary = "그림 검사",
             description = "요청받은 이미지에 대한 심리 분석 결과를 제공합니다."
     )
-    @ApiResponses(value={
+    @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "분석이 완료되었습니다.")
     })
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<InterpretResponse> inspectPicture(
             @AuthenticationPrincipal final AuthenticationDto auth,
             @RequestPart(value = "file") final MultipartFile image
     ) {
         return ResponseEntity.ok(pictureService.inspect(auth.id(), image));
+    }
+
+    @Operation(
+            summary = "그림 검사 상세 조회",
+            description = "요청한 ID의 그림 검사 결과의 상세 정보를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "분석이 완료되었습니다.")
+    })
+    @GetMapping("/{pictureId}")
+    public ResponseEntity<PictureResponse> getPicture(
+            @AuthenticationPrincipal final AuthenticationDto auth,
+            @PathVariable final Long pictureId
+    ) {
+        return ResponseEntity.ok(pictureService.getPicture(auth.id(), pictureId));
     }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `feature/13-picture`

### 💡 작업동기
- 그림 검사 상세 조회 API가 필요합니다.
- 그림 검사 제목 수정 API가 필요합니다.

### 🔑 주요 변경사항
- `PictureService`: `getPicture` 메서드 구현
- `PictureController`: `getPicture` 메서드 구현
- `PictureResponse` Dto 추가
- `PictureService`: `updateTitle` 메서드 구현
- `PictureController`: `updateTitle` 메서드 구현
- `UpdateTitleRequest` Dto 추가
- `Picture` 생성자 파라미터에 `final` 속성 추가

### 🏞 스크린샷
N/A

### 관련 이슈
- #13 