### PR TITLE
♻️ CHORE: Auditing 설정 추가 및 GPT 응답 추출 정규표현식 수정

### DIFF
--- a/src/main/java/shop/catchmind/CatchMindApplication.java
+++ b/src/main/java/shop/catchmind/CatchMindApplication.java
@@ -2,8 +2,10 @@ package shop.catchmind;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CatchMindApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/shop/catchmind/picture/application/PictureService.java
+++ b/src/main/java/shop/catchmind/picture/application/PictureService.java
@@ -95,9 +95,9 @@ public class PictureService {
         picture.updateTitle(request.title());
     }
 
-    // 정규 표현식을 사용하여 "(숫자)" 패턴을 제거
+    // 정규 표현식을 사용하여 "(숫자, 문자)" 패턴을 제거
     private String removeNumbersInParentheses(final String input) {
-        return input.replaceAll("\\(\\d+\\)", "");
+        return input.replaceAll("\\(.*?\\)", "");
     }
 
     // 요청한 ID를 가진 그림 검사 결과가 요청한 유저의 검사인지 확인하는 메서드


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `chore/32-auditing`

### 💡 작업동기
- `Auditing`에 대한 설정이 필요합니다.
- GPT 응답에서 추출할 때 사용하는 정규표현식의 수정이 필요합니다.

### 🔑 주요 변경사항
- `@EnableJpaAuditing` 추가

### 🏞 스크린샷
N/A

### 관련 이슈
- close #32 