### PR TITLE
:bug: FIX: 마이페이지 검시 리스트 최신순 정렬

### DIFF
--- a/src/main/java/shop/catchmind/member/application/MemberService.java
+++ b/src/main/java/shop/catchmind/member/application/MemberService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.catchmind.member.domain.Member;
@@ -42,7 +43,8 @@ public class MemberService {
         SimpleMemberDto simpleMemberDto = SimpleMemberDto.of(memberDto);
 
         // 그림 목록 조회 (페이지네이션 적용)
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+
         Page<Picture> picturePage = pictureRepository.findAllByMemberId(memberId, pageable);
         List<SimplePictureDto> simplePictureDtoList = picturePage.stream()
                 .map(PictureDto::of)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- fix/37-mypage

### 💡 작업동기
- 무한스크롤을 적용했지만 프론트에서만 최신순 정렬을 하여 제대로 된 최신순 정렬이 되지 않는 문제가 있었다.

### 🔑 주요 변경사항
- 마이페이지 검시 리스트 최신순 정렬

### 🏞 스크린샷
N/A

### 관련 이슈
- close #37 