### PR TITLE
🔧 CHORE: Redis OSS 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/shop/catchmind/global/config/RedisConfig.java
+++ b/src/main/java/shop/catchmind/global/config/RedisConfig.java
@@ -1,0 +1,44 @@
+package shop.catchmind.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort()); // Lettuce를 사용해서 Redis 서버와 연결해 준다.
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>(); //Redis 데이터를 저장하고 조회하는 기능을 하는 클래스
+
+        // 일반적인 key: value의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        // Hash를 사용할 경우 시리얼라이저
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        // 모든 경우
+        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/shop/catchmind/member/domain/Member.java
+++ b/src/main/java/shop/catchmind/member/domain/Member.java
@@ -33,10 +33,14 @@ public class Member extends AuditingField {
     @Column(name = "password", nullable = false)
     private String password;
 
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
     @Builder
-    public Member(final String name, final String email, final String password) {
+    public Member(final String name, final String email, final String password, final String refreshToken) {
         this.name = name;
         this.email = email;
         this.password = password;
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,10 @@ spring:
     hikari:
       data-source-properties:
         rewriteBatchedStatements: true
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
   servlet:
     multipart:
       max-file-size: 5MB


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `chore/44-redis`

### 💡 작업동기
- 인증 토큰 관리를 위한 캐시 세팅이 필요합니다.

### 🔑 주요 변경사항
- AWS로부터 Redis Cache OSS 서버를 사용합니다.
- 토큰 관리에 Redis를 쓸 수 있도록 세팅합니다.

### 🏞 스크린샷
- N/A

### 관련 이슈
- #44 