### PR TITLE
:sparkles: FEAT: 검사 API DTO 수정

### DIFF
--- a/src/main/java/shop/catchmind/picture/application/PictureService.java
+++ b/src/main/java/shop/catchmind/picture/application/PictureService.java
@@ -21,7 +21,7 @@ import shop.catchmind.picture.domain.Picture;
 import shop.catchmind.picture.domain.PictureType;
 import shop.catchmind.picture.domain.Result;
 import shop.catchmind.picture.dto.PictureDto;
-import shop.catchmind.picture.dto.PictureRequestDto;
+import shop.catchmind.picture.dto.request.InspectRequest;
 import shop.catchmind.picture.dto.request.RecognizeRequest;
 import shop.catchmind.picture.dto.request.UpdateTitleRequest;
 import shop.catchmind.picture.dto.response.GetPictureResponse;
@@ -59,12 +59,12 @@ public class PictureService {
     }
 
     @Transactional
-    public InterpretResponse inspect(final Long authId, final List<PictureRequestDto> request) {
+    public InterpretResponse inspect(final Long authId, final InspectRequest request) {
         Result result = resultRepository.save(Result.builder()
                 .memberId(authId)
                 .build());
 
-        List<Picture> pictureList = request.stream()
+        List<Picture> pictureList = request.pictureRequestDtoList().stream()
                 .map(pictureRequestDto -> {
                     String imageUrl = s3Provider.uploadFile(s3Provider.generateFilesKeyName(), pictureRequestDto.image());
                     if (pictureRequestDto.pictureType() == PictureType.TREE) {

--- a/src/main/java/shop/catchmind/picture/dto/request/InspectRequest.java
+++ b/src/main/java/shop/catchmind/picture/dto/request/InspectRequest.java
@@ -1,0 +1,12 @@
+package shop.catchmind.picture.dto.request;
+
+import shop.catchmind.picture.dto.PictureRequestDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record InspectRequest(
+        List<PictureRequestDto> pictureRequestDtoList,
+        LocalDateTime requiredTime
+) {
+}

--- a/src/main/java/shop/catchmind/picture/presentation/PictureController.java
+++ b/src/main/java/shop/catchmind/picture/presentation/PictureController.java
@@ -13,14 +13,12 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import shop.catchmind.auth.dto.AuthenticationDto;
 import shop.catchmind.picture.application.PictureService;
-import shop.catchmind.picture.dto.PictureRequestDto;
+import shop.catchmind.picture.dto.request.InspectRequest;
 import shop.catchmind.picture.dto.request.RecognizeRequest;
 import shop.catchmind.picture.dto.request.UpdateTitleRequest;
 import shop.catchmind.picture.dto.response.GetPictureResponse;
 import shop.catchmind.picture.dto.response.InterpretResponse;
 import shop.catchmind.picture.dto.response.RecognitionResultResponse;
-
-import java.util.List;
 
 @Tag(name = "Picture API", description = "그림 검사 관련 API")
 @RestController
@@ -55,9 +53,9 @@ public class PictureController {
     @PostMapping(value = "/analysis",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<InterpretResponse> inspectPicture(
             @AuthenticationPrincipal final AuthenticationDto auth,
-            @RequestPart(value = "pictureRequestList") final List<PictureRequestDto> pictureRequestDtoList
+            @RequestPart(value = "inspectRequest") final InspectRequest inspectRequest
     ) {
-        return ResponseEntity.ok(pictureService.inspect(auth.id(), pictureRequestDtoList));
+        return ResponseEntity.ok(pictureService.inspect(auth.id(), inspectRequest));
     }
 
     @Operation(


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- `feat/40-picture`

### 💡 작업동기
- 검사 API 요청 DTO에 일부 필드가 누락되었습니다.

### 🔑 주요 변경사항
- 소요 시간 필드를 추가합니다.

### 🏞 스크린샷
- N/A

### 관련 이슈
- #40 