### PR TITLE
:sparkles: FEAT: 로그아웃 컨트롤러 및 블랙리스트 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,6 @@ dependencies {
 
 	// JWT
 	implementation 'com.auth0:java-jwt:4.2.1'
-	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
-	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
-	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
   
 	// Swagger
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 
 	// JWT
 	implementation 'com.auth0:java-jwt:4.2.1'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
   
 	// Swagger
 	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.3.0'

--- a/src/main/java/shop/catchmind/auth/application/AuthService.java
+++ b/src/main/java/shop/catchmind/auth/application/AuthService.java
@@ -1,13 +1,18 @@
 package shop.catchmind.auth.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import shop.catchmind.auth.dto.request.SignUpRequest;
 import shop.catchmind.auth.dto.response.IsExistedEmailResponse;
+import shop.catchmind.auth.provider.JwtProvider;
 import shop.catchmind.member.domain.Member;
 import shop.catchmind.member.repository.MemberRepository;
+
+import java.util.concurrent.TimeUnit;
 
 @Service
 @Transactional(readOnly = true)
@@ -16,6 +21,8 @@ public class AuthService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RedisTemplate redisTemplate;
+    private final JwtProvider jwtProvider;
 
     @Transactional
     public void signUp(final SignUpRequest request) {
@@ -27,5 +34,14 @@ public class AuthService {
         return IsExistedEmailResponse.builder()
                 .isExisted(memberRepository.existsByEmail(email))
                 .build();
+    }
+
+    public void logout(final String bearerToken) {
+        String accessToken = bearerToken.substring(7);
+        ValueOperations<String, String> stringValueOperations = redisTemplate.opsForValue();
+
+        long remainingExpirationTime = jwtProvider.getRemainingExpirationTime(accessToken);
+
+        stringValueOperations.set("logout", accessToken, remainingExpirationTime, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/shop/catchmind/auth/application/AuthService.java
+++ b/src/main/java/shop/catchmind/auth/application/AuthService.java
@@ -13,6 +13,7 @@ import shop.catchmind.member.domain.Member;
 import shop.catchmind.member.repository.MemberRepository;
 
 import java.util.concurrent.TimeUnit;
+import static shop.catchmind.auth.constant.JwtConstant.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -42,6 +43,6 @@ public class AuthService {
 
         long remainingExpirationTime = jwtProvider.getRemainingExpirationTime(accessToken);
 
-        stringValueOperations.set("logout", accessToken, remainingExpirationTime, TimeUnit.SECONDS);
+        stringValueOperations.set(REDIS_LOGOUT_KEY, accessToken, remainingExpirationTime, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/shop/catchmind/auth/constant/JwtConstant.java
+++ b/src/main/java/shop/catchmind/auth/constant/JwtConstant.java
@@ -6,4 +6,5 @@ public final class JwtConstant {
     public static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
     public static final String ID_CLAIM = "id";
     public static final String BEARER_CLAIM = "Bearer";
+    public static final String REDIS_LOGOUT_KEY = "logout";
 }

--- a/src/main/java/shop/catchmind/auth/presentation/AuthController.java
+++ b/src/main/java/shop/catchmind/auth/presentation/AuthController.java
@@ -6,11 +6,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import shop.catchmind.auth.application.AuthService;
 import shop.catchmind.auth.dto.request.SignUpRequest;
 import shop.catchmind.auth.dto.response.IsExistedEmailResponse;
+
+import java.util.Objects;
 
 @Tag(name = "Auth API", description = "인증/인가 관련 API")
 @RestController
@@ -33,6 +36,22 @@ public class AuthController {
             @RequestBody @Valid final SignUpRequest request
     ) {
         authService.signUp(request);
+        return ResponseEntity.ok(null);
+    }
+
+    @Operation(
+            summary = "로그아웃",
+            description = "로그아웃을 진행합니다."
+    )
+    @ApiResponses(value={
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공입니다."),
+            @ApiResponse(responseCode = "400", description = "로그아웃 실패입니다.")
+    })
+    @PostMapping("/logout")
+    public ResponseEntity<Object> logout(
+            @RequestHeader @Valid final HttpHeaders header
+            ) {
+        authService.logout(Objects.requireNonNull(header.getFirst("Authorization")));
         return ResponseEntity.ok(null);
     }
 

--- a/src/main/java/shop/catchmind/auth/provider/JwtProvider.java
+++ b/src/main/java/shop/catchmind/auth/provider/JwtProvider.java
@@ -1,7 +1,9 @@
 package shop.catchmind.auth.provider;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
@@ -81,4 +83,19 @@ public class JwtProvider {
         }
     }
 
+    public long getRemainingExpirationTime(String accessToken) {
+        Algorithm algorithm = Algorithm.HMAC512(secretKey);
+
+        JWTVerifier verifier = JWT.require(algorithm)
+                .build();
+
+        DecodedJWT decodedJWT = verifier.verify(accessToken);
+
+        Date expiration = decodedJWT.getExpiresAt();
+        Date now = new Date();
+
+        long remainingTimeInMillis = expiration.getTime() - now.getTime();
+
+        return remainingTimeInMillis / 1000;
+    }
 }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 작업중인 브랜치
- feautre/41-auth

### 💡 작업동기
- 로그아웃 구현을 위한 레디스 블랙리스트 세팅

### 🔑 주요 변경사항
- `JwtProvider` -> 토큰에서 만료시간 추출하는 메서드 생성
- `AuthController` -> 로그아웃 컨트롤러 생성
- `AuthService` -> 로그아웃 시, 레디스 블랙리스트 세팅하는 메서드 구현


### 🏞 스크린샷
N/A

### 관련 이슈
- #41 